### PR TITLE
fixed issue where updateValue was returning  if a valid value was ins…

### DIFF
--- a/Sources/OrderedDictionary.swift
+++ b/Sources/OrderedDictionary.swift
@@ -73,12 +73,12 @@ public struct OrderedDictionary<Key: Hashable, Value>: MutableCollectionType {
             
             _keysToValues[key] = value
             
-            return currentValue
+            return _keysToValues[key]
         } else {
             _orderedKeys.append(key)
             _keysToValues[key] = value
             
-            return nil
+            return _keysToValues[key]
         }
     }
     


### PR DESCRIPTION
If OrderedDictionary does not contain a value and `updateValue` is called to insert a valid non-nil value into it, `updateValue` will return `nil` rather than the value that was just inserted. Similarly, if OrderedDictionary _does_ contain a value for a certain key and `updateValue` is called to update the value for that key, the value _before_ the update will be returned. This is problematic for Swift value-types. 

The `updateValue` method has been changed to return the latest value for a key, guaranteeing consistency.
