### PR TITLE
Add swift package manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:4.0
+
+import PackageDescription
+
+let package = Package(
+    name: "OrderedDictionary",
+    products: [
+        .library(name: "OrderedDictionary", targets: ["OrderedDictionary"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "OrderedDictionary",
+            path: "./Sources"
+        ),
+        .testTarget(
+            name: "OrderedDictionaryTests",
+            dependencies: ["OrderedDictionary"],
+            path: "./Tests"
+        ),
+    ]
+)


### PR DESCRIPTION
Closes #42 

All tests are passing with `swift test` as well.

Now allows the library to be required via spm, example Package.swift: 

```swift
// swift-tools-version:4.0

import PackageDescription

let package = Package(
    name: "MyLib",
    products: [
        .library(name: "MyLib", targets: ["MyLib"]),
    ],
    dependencies: [
        .package(url: "https://github.com/jnordberg/OrderedDictionary.git", .branch("swiftpm")),
    ],
    targets: [
        .target(
            name: "MyLib",
            dependencies: ["OrderedDictionary"]
        )
)
```
