### PR TITLE
Update package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,5 +23,5 @@ let package = Package(
             path: "Tests"
         )
     ],
-    swiftLanguageVersions: [.v4, .v4_2]
+    swiftLanguageVersions: [4]
 )


### PR DESCRIPTION
`swiftLanguageVersions` needs to be an `Int`
*Per*
https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescriptionV4.md#package
and
https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescriptionV4.md#swiftlanguageversions

This is causing a failing CI test for me.
```
Fetching https://github.com/lukaskubanek/OrderedDictionary.git
https://github.com/lukaskubanek/OrderedDictionary.git @ master: error: manifest parse error(s):
/var/folders/gk/lkr9pm5x039fx6d3j9r52rv80000gn/T/TemporaryFile.6VrSX5.swift:26:30: error: type 'Int' has no member 'v4'
    swiftLanguageVersions: [.v4, .v4_2]
```