### PR TITLE
Issue #10: Safe for app extensions

### DIFF
--- a/OrderedDictionary.xcodeproj/project.pbxproj
+++ b/OrderedDictionary.xcodeproj/project.pbxproj
@@ -577,6 +577,7 @@
 		80B28EA91E201EC9007E3A77 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -598,6 +599,7 @@
 		80B28EAA1E201EC9007E3A77 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";


### PR DESCRIPTION
• Checked the "Require Only App-Extension-Safe API" box in the Build Settings for the OrderedDictionary-iOS target.